### PR TITLE
.NET July 2025 Update

### DIFF
--- a/src/changelog.dotnet8.jammy
+++ b/src/changelog.dotnet8.jammy
@@ -1,3 +1,9 @@
+dotnet8 (8.0.118-8.0.18-0ubuntu1~22.04.1) jammy; urgency=medium
+
+  * New upstream release (LP: #2115829)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet8 (8.0.117-8.0.17-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet8.noble
+++ b/src/changelog.dotnet8.noble
@@ -1,3 +1,9 @@
+dotnet8 (8.0.118-8.0.18-0ubuntu1~24.04.1) noble; urgency=medium
+
+  * New upstream release (LP: #2115829)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet8 (8.0.117-8.0.17-0ubuntu1~24.04.1) noble; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet8.oracular
+++ b/src/changelog.dotnet8.oracular
@@ -1,3 +1,9 @@
+dotnet8 (8.0.118-8.0.18-0ubuntu1~24.10.1) oracular; urgency=medium
+
+  * New upstream release (LP: #2115829)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet8 (8.0.117-8.0.17-0ubuntu1~24.10.1) oracular; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet8.plucky
+++ b/src/changelog.dotnet8.plucky
@@ -1,3 +1,9 @@
+dotnet8 (8.0.118-8.0.18-0ubuntu1~25.04.1) plucky; urgency=medium
+
+  * New upstream release (LP: #2115829)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet8 (8.0.117-8.0.17-0ubuntu1~25.04.1) plucky; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet8.questing
+++ b/src/changelog.dotnet8.questing
@@ -1,3 +1,9 @@
+dotnet8 (8.0.118-8.0.18-0ubuntu1) questing; urgency=medium
+
+  * New upstream release (LP: #2115829)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet8 (8.0.117-8.0.17-0ubuntu1) questing; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet9.jammy
+++ b/src/changelog.dotnet9.jammy
@@ -1,3 +1,9 @@
+dotnet9 (9.0.108-9.0.7-0ubuntu1~22.04.1~ppa1) jammy; urgency=medium
+
+  * New upstream release (LP: #2115830)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet9 (9.0.107-9.0.6-0ubuntu1~22.04.1~ppa1) jammy; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet9.noble
+++ b/src/changelog.dotnet9.noble
@@ -1,3 +1,9 @@
+dotnet9 (9.0.108-9.0.7-0ubuntu1~24.04.1~ppa1) noble; urgency=medium
+
+  * New upstream release (LP: #2115830)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet9 (9.0.107-9.0.6-0ubuntu1~24.04.1~ppa1) noble; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet9.oracular
+++ b/src/changelog.dotnet9.oracular
@@ -1,3 +1,9 @@
+dotnet9 (9.0.108-9.0.7-0ubuntu1~24.10.1) oracular; urgency=medium
+
+  * New upstream release (LP: #2115830)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet9 (9.0.107-9.0.6-0ubuntu1~24.10.1) oracular; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet9.plucky
+++ b/src/changelog.dotnet9.plucky
@@ -1,3 +1,9 @@
+dotnet9 (9.0.108-9.0.7-0ubuntu1~25.04.1) plucky; urgency=medium
+
+  * New upstream release (LP: #2115830)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet9 (9.0.107-9.0.6-0ubuntu1~25.04.1) plucky; urgency=medium
 
   * New upstream release

--- a/src/changelog.dotnet9.questing
+++ b/src/changelog.dotnet9.questing
@@ -1,3 +1,9 @@
+dotnet9 (9.0.108-9.0.7-0ubuntu1) questing; urgency=medium
+
+  * New upstream release (LP: #2115830)
+
+ -- Dominik Viererbe <dominik.viererbe@canonical.com>  Wed, 02 Jul 2025 16:38:30 +0300
+
 dotnet9 (9.0.107-9.0.6-0ubuntu1) questing; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
Changes for the .NET July 2025 Update

Release Date: 8th July 2025

See also:
- .NET 8 SRU bug (LP: [#2115829](https://bugs.launchpad.net/ubuntu/+source/dotnet8/+bug/2115829))
- .NET 9 SRU bug (LP: [#2115830](https://bugs.launchpad.net/ubuntu/+source/dotnet9/+bug/2115830))
- Builds for testing are available via this PPA: https://launchpad.net/~dotnet/+archive/ubuntu/testing


