### PR TITLE
Enable riscv64 for dotnet10

### DIFF
--- a/eng/build-orig-tarball.py
+++ b/eng/build-orig-tarball.py
@@ -518,7 +518,7 @@ def CheckBootstrappingPrerequisites(context: InvocationContext) -> None:
     match context.BootstrapSdkArchitecture:
         case None:
             return
-        case "amd64" | "arm64" | "s390x" | "ppc64el":
+        case "amd64" | "arm64" | "s390x" | "ppc64el" | "riscv64":
             if context.HostDpkgArchitecture != context.BootstrapSdkArchitecture:  # noqa: E501
                 LogErrorAndExit(
                     "You need to run this script on an "
@@ -647,8 +647,8 @@ def RunBinaryToolkit(context: InvocationContext) -> None:
 
     print("Running binary toolkit...", flush=True)
 
-    if context.BootstrapSdkArchitecture in ["s390x", "ppc64el"]:
-        # NOTE: For s390x and ppc64el we unpack the bootstrapped .NET SDK
+    if context.BootstrapSdkArchitecture in ["s390x", "ppc64el", "riscv64"]:
+        # NOTE: For s390x, ppc64el and riscv64 we unpack the bootstrapped .NET SDK
         #       into $repoRoot/dotnet. The Binary Remover will then
         #       inadvertently remove the binaries inside this directory
         #       and break the bootstrap SDK in the process. For that reason,

--- a/src/control.dotnet10
+++ b/src/control.dotnet10
@@ -28,7 +28,7 @@ Rules-Requires-Root: binary-targets
 Homepage: https://dot.net
 
 Package: dotnet10
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet6 (<< 6.0.111~)
 Description: .NET CLI tools and runtime
@@ -43,7 +43,7 @@ Description: .NET CLI tools and runtime
  CLI application to drive everything.
 
 Package: dotnet-host-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Conflicts: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
 Replaces: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
@@ -59,7 +59,7 @@ Description: .NET host command line
  applications, and micro-services.
 
 Package: dotnet-hostfxr-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-hostfxr-6.0 (<< 6.0.111~)
 Description: .NET host resolver
@@ -73,7 +73,7 @@ Description: .NET host resolver
  applications, and micro-services.
 
 Package: dotnet-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-hostfxr-10.0,
          ${libicu:Depends},
          ${misc:Depends},
@@ -92,7 +92,7 @@ Description: .NET runtime
  applications, and micro-services.
 
 Package: aspnetcore-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Suggests: aspnetcore-runtime-dbg-10.0
 Breaks: aspnetcore-runtime-6.0 (<< 6.0.111~)
@@ -108,7 +108,7 @@ Description: ASP.NET Core runtime
  applications, and micro-services.
 
 Package: dotnet-templates-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-templates-6.0 (<< 6.0.111~)
 Description: .NET 10.0 templates
@@ -121,7 +121,7 @@ Description: .NET 10.0 templates
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0,
          aspnetcore-targeting-pack-10.0,
          dotnet-apphost-pack-10.0,
@@ -145,7 +145,7 @@ Description: .NET 10.0 Software Development Kit
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0-source-built-artifacts
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Internal package for building the .NET 10.0 Software Development Kit
  The .NET source-built archive is a collection of packages needed
@@ -160,7 +160,7 @@ Description: .NET platform NativeAOT components.
  This package provides the SDK components for platform NativeAOT.
 
 Package: dotnet-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -169,7 +169,7 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This are not meant for general use.
 
 Package: aspnetcore-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: aspnetcore-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
@@ -179,7 +179,7 @@ Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
  This are not meant for general use.
 
 Package: dotnet-apphost-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-apphost-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -188,19 +188,19 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This not meant for general use.
 
 Package: aspnetcore-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: ASP.NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.AspNetCore.App 10.0.
 
 Package: dotnet-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.NETCore.App 10.0.
 
 Package: dotnet-sdk-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET SDK debug symbols.
  This package provides the PDB debug symbols for the .NET 10.0 SDK.

--- a/src/control.dotnet10.jammy
+++ b/src/control.dotnet10.jammy
@@ -28,7 +28,7 @@ Rules-Requires-Root: binary-targets
 Homepage: https://dot.net
 
 Package: dotnet10
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet6 (<< 6.0.111~)
 Description: .NET CLI tools and runtime
@@ -43,7 +43,7 @@ Description: .NET CLI tools and runtime
  CLI application to drive everything.
 
 Package: dotnet-host-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Conflicts: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
 Replaces: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
@@ -59,7 +59,7 @@ Description: .NET host command line
  applications, and micro-services.
 
 Package: dotnet-hostfxr-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-hostfxr-6.0 (<< 6.0.111~)
 Description: .NET host resolver
@@ -73,7 +73,7 @@ Description: .NET host resolver
  applications, and micro-services.
 
 Package: dotnet-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-hostfxr-10.0,
          ${libicu:Depends},
          ${misc:Depends},
@@ -92,7 +92,7 @@ Description: .NET runtime
  applications, and micro-services.
 
 Package: aspnetcore-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Suggests: aspnetcore-runtime-dbg-10.0
 Breaks: aspnetcore-runtime-6.0 (<< 6.0.111~)
@@ -108,7 +108,7 @@ Description: ASP.NET Core runtime
  applications, and micro-services.
 
 Package: dotnet-templates-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-templates-6.0 (<< 6.0.111~)
 Description: .NET 10.0 templates
@@ -121,7 +121,7 @@ Description: .NET 10.0 templates
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0,
          aspnetcore-targeting-pack-10.0,
          dotnet-apphost-pack-10.0,
@@ -145,7 +145,7 @@ Description: .NET 10.0 Software Development Kit
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0-source-built-artifacts
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Internal package for building the .NET 10.0 Software Development Kit
  The .NET source-built archive is a collection of packages needed
@@ -160,7 +160,7 @@ Description: .NET platform NativeAOT components.
  This package provides the SDK components for platform NativeAOT.
 
 Package: dotnet-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -169,7 +169,7 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This are not meant for general use.
 
 Package: aspnetcore-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: aspnetcore-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
@@ -179,7 +179,7 @@ Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
  This are not meant for general use.
 
 Package: dotnet-apphost-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-apphost-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -188,19 +188,19 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This not meant for general use.
 
 Package: aspnetcore-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: ASP.NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.AspNetCore.App 10.0.
 
 Package: dotnet-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.NETCore.App 10.0.
 
 Package: dotnet-sdk-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET SDK debug symbols.
  This package provides the PDB debug symbols for the .NET 10.0 SDK.

--- a/src/control.dotnet10.resolute
+++ b/src/control.dotnet10.resolute
@@ -28,7 +28,7 @@ Rules-Requires-Root: binary-targets
 Homepage: https://dot.net
 
 Package: dotnet10
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet6 (<< 6.0.111~)
 Description: .NET CLI tools and runtime
@@ -43,7 +43,7 @@ Description: .NET CLI tools and runtime
  CLI application to drive everything.
 
 Package: dotnet-host-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Conflicts: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
 Replaces: dotnet-host, dotnet-host-7.0, dotnet-host-8.0, dotnet-host-9.0
@@ -59,7 +59,7 @@ Description: .NET host command line
  applications, and micro-services.
 
 Package: dotnet-hostfxr-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-hostfxr-6.0 (<< 6.0.111~)
 Description: .NET host resolver
@@ -73,7 +73,7 @@ Description: .NET host resolver
  applications, and micro-services.
 
 Package: dotnet-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-hostfxr-10.0,
          ${libicu:Depends},
          ${misc:Depends},
@@ -92,7 +92,7 @@ Description: .NET runtime
  applications, and micro-services.
 
 Package: aspnetcore-runtime-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Suggests: aspnetcore-runtime-dbg-10.0
 Breaks: aspnetcore-runtime-6.0 (<< 6.0.111~)
@@ -108,7 +108,7 @@ Description: ASP.NET Core runtime
  applications, and micro-services.
 
 Package: dotnet-templates-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-host-10.0, ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-templates-6.0 (<< 6.0.111~)
 Description: .NET 10.0 templates
@@ -121,7 +121,7 @@ Description: .NET 10.0 templates
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0,
          aspnetcore-targeting-pack-10.0,
          dotnet-apphost-pack-10.0,
@@ -145,7 +145,7 @@ Description: .NET 10.0 Software Development Kit
  applications, and micro-services.
 
 Package: dotnet-sdk-10.0-source-built-artifacts
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Internal package for building the .NET 10.0 Software Development Kit
  The .NET source-built archive is a collection of packages needed
@@ -160,7 +160,7 @@ Description: .NET platform NativeAOT components.
  This package provides the SDK components for platform NativeAOT.
 
 Package: dotnet-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -169,7 +169,7 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This are not meant for general use.
 
 Package: aspnetcore-targeting-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: aspnetcore-targeting-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
@@ -179,7 +179,7 @@ Description: Internal - targeting pack for Microsoft.AspNetCore.App 10.0
  This are not meant for general use.
 
 Package: dotnet-apphost-pack-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Breaks: dotnet-apphost-pack-6.0 (<< 6.0.111~)
 Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
@@ -188,19 +188,19 @@ Description: Internal - targeting pack for Microsoft.NETCore.App 10.0
  applications using the .NET SDK. This not meant for general use.
 
 Package: aspnetcore-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: aspnetcore-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: ASP.NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.AspNetCore.App 10.0.
 
 Package: dotnet-runtime-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-runtime-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET Runtime debug symbols.
  This package provides the PDB debug symbols for Microsoft.NETCore.App 10.0.
 
 Package: dotnet-sdk-dbg-10.0
-Architecture: amd64 arm64 s390x ppc64el
+Architecture: amd64 arm64 s390x ppc64el riscv64
 Depends: dotnet-sdk-10.0, ${misc:Depends}, ${shlibs:Depends}
 Description: .NET SDK debug symbols.
  This package provides the PDB debug symbols for the .NET 10.0 SDK.

--- a/src/eng/versionlib/dotnet.py
+++ b/src/eng/versionlib/dotnet.py
@@ -332,6 +332,7 @@ class ArchitectureIdentifier(StrEnum):
     ARM64 = "arm64"
     S390X = "s390x"
     PPC64LE = "ppc64le"
+    RISCV64 = "riscv64"
 
     @staticmethod
     def ParseMachineIdentifier(machineIdentifier: str) -> 'ArchitectureIdentifier':  # noqa: E501
@@ -344,6 +345,8 @@ class ArchitectureIdentifier(StrEnum):
                 return ArchitectureIdentifier.S390X
             case "ppc64le":
                 return ArchitectureIdentifier.PPC64LE
+            case "riscv64":
+                return ArchitectureIdentifier.RISCV64
             case _:
                 raise RuntimeError(f"{machineIdentifier} is an "
                                    "unknown/unsupported system architecture.")


### PR DESCRIPTION
People are using community build: https://github.com/filipnavara/dotnet-riscv/releases/tag/10.0.100. Official build would be preferred.